### PR TITLE
v3.0: Pin/Unpin packages from importmap and new Clips based on DHH Ruby bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Version 3.0
+
+### FEATURES
+
+-   Added new commands for pinning and unpinning packages from importmap
+
 ## Version 2.0
 
 ### FEATURES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### FEATURES
 
 -   Added new commands for pinning and unpinning packages from importmap
+-   Added new Clips for ERB, Ruby and Rails based on *DHH Ruby* bundle for TextMate
 
 ## Version 2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 -   Added new commands for pinning and unpinning packages from importmap
 -   Added new Clips for ERB, Ruby and Rails based on *DHH Ruby* bundle for TextMate
 
+### DOCS
+
+-   Streamlined and updated the README.
+
 ## Version 2.0
 
 ### FEATURES

--- a/README.md
+++ b/README.md
@@ -2,56 +2,44 @@
 
 # Ruby on Rails for Nova editor
 
-This extension is still in Alpha and various features will be added later on. If you have any suggestion or you have some free time you are free to contribute.
+Provides Ruby & Ruby on Rails support for Panic's Nova text editor.
 
-Visit the [Wiki](https://github.com/tommasongr/nova-rails/wiki) for seeing all the available commands and features.
+## Usage
 
-## NEW: Solargraph support 🚀
+Enable the extension in the extension library within Nova.
 
-Nova Rails v1.0 ships with Solargraph support and almost all its settings exposed. You can configure it globally or on a workspace base.
+## Features Overview
 
-> WARNING: Due to an oversight in previous versions you must have Solargraph v0.42.0 or above to access the settings.
+### Solargraph
 
-## Features
+The extension provides Solargraph support with almost all its settings exposed. You can configure it globally or on a workspace base. You must have [Solargraph](https://solargraph.org) already installed.
 
-### Rails Server Task
+> WARNING: Solargraph v0.42.0 or above is required.
 
-Automatically generate a Task for running the Rails Server command.
+### Database & Migrations
 
-### Search in various documentations
+The extension provides commands for migrating/rolling back the database, opening quickly the last migration and list all migrations within a command palette.
 
-Run the Search Documentation command for searching in different documentations online.
+### Alternate Files
 
-### Open the last migration or list them all
-
-Run the Last Migration or the List Migrations commands for streamlining those operations.
-
-### Open Alternate File
-
-Run the Open Alternate File for rapidly switching between tests and model/controller/etc files.
-
-### ERB Tag Switcher
-
-Quickly switch between `<%`, `<%=` & `<%#` with a single shortcut.
-
-Select a text to wrap it in ERB tags or just use `⌘-shift->` to create a tag and start typing the expression.
+Quickly switch between tests and model/controller/etc files.
 
 ### Stimulus Clips
 
-Start typing `Stimu...` in Javascript and HTML files for inserting Stimulus completions like Controller Scaffold, actions, classes, etc. Placeholders are formatted with the correct naming conventions.
-
-Stimulus Clips work also in Javascript and HTML derivate syntaxes like Typescript and HTML(ERB).\_
+Quickly insert Stimulus notations. To access the Clips start typing `stimul...`. You can use placeholders for referencing the correct naming conventions.
 
 ![Stimulus Clips](https://raw.githubusercontent.com/tommasongr/nova-rails/main/docs/images/stimulus-clips.png)
 
-## Features on their way
+### And much more...
 
--   Solargraph support
--   Solargrah settings exposed
--   Scaffolding Solargraph Files for better Rails Support
+ERB tag switcher, Search in various documentations, Rails Server Task, DHH Ruby Clips, About Rails Sidebar, show routes and infos, importmap pin and unpin commands, update Stimulus manifest...
 
-## Contributors
+Check out the [Wiki](https://github.com/tommasongr/nova-rails/wiki) for a complete reference.
 
-You are welcome to contribute in any way you can think of!
+## Report a Bug or Feature Request
+
+To report a bug or request a feature, please add an issue to the GitHub repository. Thanks!
+
+## Special Thanks
 
 Thanks to @devjah, @jonathanpike and @Wylan for their work on different extensions which have been integrated in this suite.

--- a/Rails.novaextension/CHANGELOG.md
+++ b/Rails.novaextension/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Version 3.0
+
+### FEATURES
+
+-   Added new commands for pinning and unpinning packages from importmap
+-   Added new Clips for ERB, Ruby and Rails based on *DHH Ruby* bundle for TextMate
+
 ## Version 2.0
 
 ### FEATURES

--- a/Rails.novaextension/CHANGELOG.md
+++ b/Rails.novaextension/CHANGELOG.md
@@ -5,6 +5,10 @@
 -   Added new commands for pinning and unpinning packages from importmap
 -   Added new Clips for ERB, Ruby and Rails based on *DHH Ruby* bundle for TextMate
 
+### DOCS
+
+-   Streamlined and updated the README.
+
 ## Version 2.0
 
 ### FEATURES

--- a/Rails.novaextension/Clips.json
+++ b/Rails.novaextension/Clips.json
@@ -1,49 +1,84 @@
 {
     "clips": [
         {
-            "name": "Stimulus (JS)",
+            "name": "ERB",
             "children": [
                 {
-                    "content": "import { Controller } from \"@hotwired/stimulus\"\n\nexport default class extends Controller {\n\t${:Code}\n}",
-                    "name": "Stimulus Controller",
+                    "content": "<% $0 %>",
+                    "name": "ERB expression",
                     "scope": "editor",
-                    "syntax": "javascript",
-                    "trigger": "stimulus controller"
+                    "shortcut": "ctrl-x",
+                    "syntax": "html+erb",
+                    "trigger": "<%"
                 },
                 {
-                    "content": "static targets = [\"${:targetName}\"]",
-                    "name": "Stimulus Targets",
+                    "content": "<%= $0 %>",
+                    "name": "ERB insert",
                     "scope": "editor",
-                    "syntax": "javascript",
-                    "trigger": "stimulus targets"
+                    "shortcut": "ctrl-z",
+                    "syntax": "html+erb",
+                    "trigger": "<%="
+                },
+            ]
+        },
+        {
+            "name": "Rails",
+            "children": [
+                {
+                    "content": "module $0\n\textend ActiveSupport::Concern\n\n\t$1\nend",
+                    "name": "concern",
+                    "scope": "editor",
+                    "syntax": "ruby",
+                    "trigger": "concern"
                 },
                 {
-                    "content": "static values = {\n\t${:valueName}: ${:Type}\n}",
-                    "name": "Stimulus Values",
+                    "content": "params[:${:id}]",
+                    "name": "params",
                     "scope": "editor",
-                    "syntax": "javascript",
-                    "trigger": "stimulus values"
+                    "shortcut": "ctrl-p",
+                    "syntax": "ruby",
+                    "trigger": "params"
                 },
                 {
-                    "content": "static values = {\n\t${:valueName}: {\n\t\ttype: ${:Type},\n\t\tdefault: ${:value}\n\t}\n}",
-                    "name": "Stimulus Values + Defaults",
+                    "content": "test \"$0\" do\n\t$1\nend",
+                    "name": "test case",
                     "scope": "editor",
-                    "syntax": "javascript",
-                    "trigger": "stimulus values defaults"
+                    "syntax": "ruby",
+                    "trigger": "test"
+                }
+            ]
+        },
+        {
+            "name": "Ruby",
+            "children": [
+                {
+                    "content": "{ |${0:e}| $1 ",
+                    "name": "block",
+                    "scope": "editor",
+                    "syntax": "ruby",
+                    "trigger": "{"
                 },
                 {
-                    "content": "static classes = [\"${:className}\"]",
-                    "name": "Stimulus Classes",
+                    "content": "do\n\t$0\nend",
+                    "name": "do/end",
                     "scope": "editor",
-                    "syntax": "javascript",
-                    "trigger": "stimulus classes"
+                    "syntax": "ruby",
+                    "trigger": "do"
                 },
                 {
-                    "content": "this.dispatch(\"${:eventName}\", { detail: ${:payloadObject} })",
-                    "name": "Stimulus Dispatch",
+                    "content": "do |$0|\n\t$1\nend",
+                    "name": "do/end yield",
                     "scope": "editor",
-                    "syntax": "javascript",
-                    "trigger": "stimulus dispatch"
+                    "syntax": "ruby",
+                    "trigger": "doo"
+                },
+                {
+                    "content": "def $0\n\t$1\nend",
+                    "name": "New method",
+                    "scope": "editor",
+                    "shortcut": "command-return",
+                    "syntax": "ruby",
+                    "trigger": "def"
                 }
             ]
         },
@@ -98,6 +133,53 @@
                     "scope": "editor",
                     "syntax": "html",
                     "trigger": "stimulus class"
+                }
+            ]
+        },
+        {
+            "name": "Stimulus (JS)",
+            "children": [
+                {
+                    "content": "import { Controller } from \"@hotwired/stimulus\"\n\nexport default class extends Controller {\n\t${:Code}\n}",
+                    "name": "Stimulus Controller",
+                    "scope": "editor",
+                    "syntax": "javascript",
+                    "trigger": "stimulus controller"
+                },
+                {
+                    "content": "static targets = [\"${:targetName}\"]",
+                    "name": "Stimulus Targets",
+                    "scope": "editor",
+                    "syntax": "javascript",
+                    "trigger": "stimulus targets"
+                },
+                {
+                    "content": "static values = {\n\t${:valueName}: ${:Type}\n}",
+                    "name": "Stimulus Values",
+                    "scope": "editor",
+                    "syntax": "javascript",
+                    "trigger": "stimulus values"
+                },
+                {
+                    "content": "static values = {\n\t${:valueName}: {\n\t\ttype: ${:Type},\n\t\tdefault: ${:value}\n\t}\n}",
+                    "name": "Stimulus Values + Defaults",
+                    "scope": "editor",
+                    "syntax": "javascript",
+                    "trigger": "stimulus values defaults"
+                },
+                {
+                    "content": "static classes = [\"${:className}\"]",
+                    "name": "Stimulus Classes",
+                    "scope": "editor",
+                    "syntax": "javascript",
+                    "trigger": "stimulus classes"
+                },
+                {
+                    "content": "this.dispatch(\"${:eventName}\", { detail: ${:payloadObject} })",
+                    "name": "Stimulus Dispatch",
+                    "scope": "editor",
+                    "syntax": "javascript",
+                    "trigger": "stimulus dispatch"
                 }
             ]
         }

--- a/Rails.novaextension/README.md
+++ b/Rails.novaextension/README.md
@@ -2,56 +2,44 @@
 
 # Ruby on Rails for Nova editor
 
-This extension is still in Alpha and various features will be added later on. If you have any suggestion or you have some free time you are free to contribute.
+Provides Ruby & Ruby on Rails support for Panic's Nova text editor.
 
-Visit the [Wiki](https://github.com/tommasongr/nova-rails/wiki) for seeing all the available commands and features.
+## Usage
 
-## NEW: Solargraph support 🚀
+Enable the extension in the extension library within Nova.
 
-Nova Rails v1.0 ships with Solargraph support and almost all its settings exposed. You can configure it globally or on a workspace base.
+## Features Overview
 
-> WARNING: Due to an oversight in previous versions you must have Solargraph v0.42.0 or above to access the settings.
+### Solargraph
 
-## Features
+The extension provides Solargraph support with almost all its settings exposed. You can configure it globally or on a workspace base. You must have [Solargraph](https://solargraph.org) already installed.
 
-### Rails Server Task
+> WARNING: Solargraph v0.42.0 or above is required.
 
-Automatically generate a Task for running the Rails Server command.
+### Database & Migrations
 
-### Search in various documentations
+The extension provides commands for migrating/rolling back the database, opening quickly the last migration and list all migrations within a command palette.
 
-Run the Search Documentation command for searching in different documentations online.
+### Alternate Files
 
-### Open the last migration or list them all
-
-Run the Last Migration or the List Migrations commands for streamlining those operations.
-
-### Open Alternate File
-
-Run the Open Alternate File for rapidly switching between tests and model/controller/etc files.
-
-### ERB Tag Switcher
-
-Quickly switch between `<%`, `<%=` & `<%#` with a single shortcut.
-
-Select a text to wrap it in ERB tags or just use `⌘-shift->` to create a tag and start typing the expression.
+Quickly switch between tests and model/controller/etc files.
 
 ### Stimulus Clips
 
-Start typing `Stimu...` in Javascript and HTML files for inserting Stimulus completions like Controller Scaffold, actions, classes, etc. Placeholders are formatted with the correct naming conventions.
-
-Stimulus Clips work also in Javascript and HTML derivate syntaxes like Typescript and HTML(ERB).\_
+Quickly insert Stimulus notations. To access the Clips start typing `stimul...`. You can use placeholders for referencing the correct naming conventions.
 
 ![Stimulus Clips](https://raw.githubusercontent.com/tommasongr/nova-rails/main/docs/images/stimulus-clips.png)
 
-## Features on their way
+### And much more...
 
--   Solargraph support
--   Solargrah settings exposed
--   Scaffolding Solargraph Files for better Rails Support
+ERB tag switcher, Search in various documentations, Rails Server Task, DHH Ruby Clips, About Rails Sidebar, show routes and infos, importmap pin and unpin commands, update Stimulus manifest...
 
-## Contributors
+Check out the [Wiki](https://github.com/tommasongr/nova-rails/wiki) for a complete reference.
 
-You are welcome to contribute in any way you can think of!
+## Report a Bug or Feature Request
+
+To report a bug or request a feature, please add an issue to the GitHub repository. Thanks!
+
+## Special Thanks
 
 Thanks to @devjah, @jonathanpike and @Wylan for their work on different extensions which have been integrated in this suite.

--- a/Rails.novaextension/extension.json
+++ b/Rails.novaextension/extension.json
@@ -3,7 +3,7 @@
     "name": "Ruby on Rails",
     "organization": "Tommaso Negri",
     "description": "Ruby on Rails and Ruby support for Nova editor.",
-    "version": "2.0",
+    "version": "3.0",
     "main": "main.dist.js",
     "license": "MIT",
     "keywords": [

--- a/Rails.novaextension/extension.json
+++ b/Rails.novaextension/extension.json
@@ -131,6 +131,14 @@
             {
                 "title": "Update Stimulus manifest",
                 "command": "tommasonegri.rails.commands.stimulus.manifest.update"
+            },
+            {
+                "title": "Pin package to importmap",
+                "command": "tommasonegri.rails.commands.importmap.pin"
+            },
+            {
+                "title": "Unpin package to importmap",
+                "command": "tommasonegri.rails.commands.importmap.unpin"
             }
         ]
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nova-rails",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Ruby on Rails and Ruby support for Nova editor.",
     "main": "src/Scripts/main.js",
     "scripts": {

--- a/src/Scripts/commands/RailsImportmap.js
+++ b/src/Scripts/commands/RailsImportmap.js
@@ -1,0 +1,75 @@
+import { showNotification } from "../helpers"
+
+export default class RailsImportmap {
+    constructor() {}
+
+    pin() {
+        const message = 'Pin one or more packages to Rails importmap. Separate package names with a blank space.'
+
+        nova.workspace.showInputPanel(message, {
+            label: 'Packages',
+            placeholder: 'lodash local-time react@17.0.1',
+            prompt: 'Pin'
+        }, packages => this.#pin_or_unpin(packages, {
+            method: 'pin'
+        }))
+    }
+
+    unpin() {
+        const message = 'Unpin one or more packages from Rails importmap. Separate package names with a blank space.'
+
+        nova.workspace.showInputPanel(message, {
+            label: 'Packages',
+            placeholder: 'lodash local-time react@17.0.1',
+            prompt: 'Unpin'
+        }, packages => this.#pin_or_unpin(packages, {
+            method: 'unpin'
+        }))
+    }
+
+    // Private
+
+    #pin_or_unpin(packages, options) {
+        const process = new Process('usr/bin/env', {
+            cwd: nova.workspace.path,
+            args: ['bin/importmap', options.method, packages],
+            stdio: ['ignore', 'pipe', 'pipe'],
+        })
+        let str = ""
+
+        process.onStdout((output) => {
+            str += output.trim()
+        })
+
+        process.onStderr(output => {
+            str += output.trim()
+        })
+
+        process.onDidExit((status) => {
+            console.log(`Importmap ${options.method} command exited with status:`, status)
+
+            if (status === 0) {
+                if (str.includes("Couldn't find any packages")) {
+                    console.warn(`Couldn't find packages:`, packages)
+
+                    nova.workspace.showWarningMessage(`Couldn't find the specified packages. Check out for typos or other reference errors.`)
+                } else {
+                    console.log(`Successfully ${options.method}ned packages:`, packages)
+
+                    showNotification(
+                        `rails-importmap-${options.method}`,
+                        `Successfully ${options.method}ned packages`,
+                        false,
+                        `The specified packages have been ${options.method}ned to the project. Check out config/importmap.rb for more information.`
+                    )
+                }
+            } else {
+                console.error(`Importmap ${options.method} command exited with error:`, str)
+
+                nova.workspace.showErrorMessage(`Something went wrong with the importmap ${options.method} command. Check out the Extension Console for more information.`)
+            }
+        })
+
+        process.start()
+    }
+}

--- a/src/Scripts/registerCommands.js
+++ b/src/Scripts/registerCommands.js
@@ -5,6 +5,7 @@ import RailsDocumentation from './commands/RailsDocumentation'
 import RailsServer from './commands/RailsServer'
 import RailsStimulus from './commands/RailsStimulus'
 import RailsInfo from './commands/RailsInfo'
+import RailsImportmap from './commands/RailsImportmap'
 
 export default function registerCommands() {
     nova.commands.register(
@@ -145,6 +146,22 @@ export default function registerCommands() {
         () => {
             const railsInfo = new RailsInfo()
             railsInfo.showProperties()
+        }
+    )
+
+    // Register Nova commands for pinning and unpinning packages from importmap
+    nova.commands.register(
+        'tommasonegri.rails.commands.importmap.pin',
+        () => {
+            const railsImportmap = new RailsImportmap()
+            railsImportmap.pin()
+        }
+    )
+    nova.commands.register(
+        'tommasonegri.rails.commands.importmap.unpin',
+        () => {
+            const railsImportmap = new RailsImportmap()
+            railsImportmap.unpin()
         }
     )
 }


### PR DESCRIPTION
## Pin/Unpin packages from importmap

This release will add two new commands. One for pinning and one for unpinning packages from the new Rails 7.0 importmap.

![CleanShot 2021-12-27 at 19 23 54](https://user-images.githubusercontent.com/25225746/147497840-639f290e-74be-4396-a11d-2586e33d510d.gif)

## Clips for ERB, Ruby and Rails based on DHH Ruby bundle

This release will add a bunch of new Clips based on [DHH Ruby bundle for TextMate](https://github.com/dhh/textmate-rails-bundle).

