### PR TITLE
✨  When rails notes/about fails to run, save the error output and return it in the Extension error logs

### DIFF
--- a/src/Scripts/helpers.js
+++ b/src/Scripts/helpers.js
@@ -65,17 +65,26 @@ export async function aboutRails() {
     const process = new Process('/usr/bin/env', {
       cwd: nova.workspace.path,
       args: ['rails', 'about'],
-      stdio: ['ignore', 'pipe', 'ignore'],
+      stdio: ['ignore', 'pipe', 'pipe'],
       shell: true,
     })
     let str = ''
+    let err = ''
     let strings = []
 
     process.onStdout((output) => {
       str += output
     })
 
+    process.onStderr((error_output) => {
+      err += error_output
+    })
+
     process.onDidExit((status) => {
+      if (status == 1 && str.length == 0) {
+        return reject(err)
+      }
+
       // Split each line of the output in the strings array
       strings = str.match(/[^\r\n]+/g)
 
@@ -97,17 +106,26 @@ export async function railsNotes() {
     const process = new Process('/usr/bin/env', {
       cwd: nova.workspace.path,
       args: ['rails', 'notes'],
-      stdio: ['ignore', 'pipe', 'ignore'],
+      stdio: ['ignore', 'pipe', 'pipe'],
       shell: true,
     })
     let str = ''
+    let err = ''
     let strings = []
 
     process.onStdout((output) => {
       str += output
     })
 
+    process.onStderr((error_output) => {
+      err += error_output
+    })
+
     process.onDidExit((status) => {
+      if (status == 1 && str.length == 0) {
+        return reject(err)
+      }
+
       const notes = []
       // Split each line of the output in the strings array
       strings = str.match(/[^\r\n]+/g)


### PR DESCRIPTION
This fixes #15.

The null is thrown because `str` the process failed to run, keeping str empty.

I'm changing the flow of both helpers a bit, if we detect that `str` is empty AND the status code is `1`, then we know something broke and we can reject the promise.

By keeping track of the error output, we can also return WHAT happened.