### PR TITLE
rails notes/about shouldn't fail when the output is empty

### DIFF
--- a/src/Scripts/helpers.js
+++ b/src/Scripts/helpers.js
@@ -81,9 +81,8 @@ export async function aboutRails() {
     })
 
     process.onDidExit((status) => {
-      if (status == 1 && str.length == 0) {
-        return reject(err)
-      }
+      if (status == 1){ return reject(err) }
+      if (str.length == 0) { return reject("rails about is empty") }
 
       // Split each line of the output in the strings array
       strings = str.match(/[^\r\n]+/g)
@@ -122,9 +121,8 @@ export async function railsNotes() {
     })
 
     process.onDidExit((status) => {
-      if (status == 1 && str.length == 0) {
-        return reject(err)
-      }
+      if (status == 1){ return reject(err) }
+      if (str.length == 0) { return reject("rails notes is empty") }
 
       const notes = []
       // Split each line of the output in the strings array


### PR DESCRIPTION
My previous fix had a wrong assumption; when running `rails notes` if it returns an error code AND the read output is empty, we can report the error.

There are more reasons to not process the output, like running it successfully and getting an empty return value.

So I've changed the behaviour:
- if there was an error exit code, do not process and report the error code.
- if the output was empty, do not process and return with a message.

This should fix the new errors reported in #15 