### PR TITLE
Update noteParts regexp to handle Notes with empty comments

### DIFF
--- a/Scripts/helpers.js
+++ b/Scripts/helpers.js
@@ -128,7 +128,7 @@ exports.railsNotes = async function() {
           }
           notes.push(notesGroup)
         } else {
-          const noteParts = /\s{2}\*\s\[\s*(\d+)\]\s\[(.*)\]\s(.+)/.exec(str)
+          const noteParts = /\s{2}\*\s\[\s*(\d+)\]\s\[(.*)\]\s?(.*)/.exec(str)
 
           const note = {
             line: noteParts[1],


### PR DESCRIPTION
The notes parser was crashing on Notes with no comment section. Eg.
```
  * [ 66] [FIXME] 
```
This change updates the regex to handle optional comments.
