### PR TITLE
Fix `onDidSave` event handling

### DIFF
--- a/Scripts/main.js
+++ b/Scripts/main.js
@@ -35,20 +35,22 @@ exports.activate = function() {
   }
 
   if (SETTINGS.rubocop.autocorrectOnSave()) {
-    nova.workspace.activeTextEditor.onDidSave((editor) => {
-      const rubocop = new COMMANDS.Rubocop()
+    nova.workspace.onDidAddTextEditor((editor) => {
+      editor.onDidSave((editor) => {
+        const rubocop = new COMMANDS.Rubocop()
 
-      switch (SETTINGS.rubocop.autocorrectOnSave()) {
-        case "Layout (recommended)":
-          rubocop.autocorrectLayout(editor.document)
-          break
-        case "Safe Cops":
-          rubocop.autocorrect(editor.document)
-          break
-        case "Safe & Unsafe Cops":
-          rubocop.autocorrectAll(editor.document)
-          break
-      }
+        switch (SETTINGS.rubocop.autocorrectOnSave()) {
+          case "Layout (recommended)":
+            rubocop.autocorrectLayout(editor.document)
+            break
+          case "Safe Cops":
+            rubocop.autocorrect(editor.document)
+            break
+          case "Safe & Unsafe Cops":
+            rubocop.autocorrectAll(editor.document)
+            break
+        }
+      })
     })
   }
 }


### PR DESCRIPTION
When the extension is activated on an empty workspace, `nova.workspace.activeTextEditor` is `undefined` which raises an unhandled exception.

Instead, add an `onDidAddTextEditor` event handler to the workspace and add `onDidSave` to the new `TextEditor` instance.

We also clean up event handlers on extension deactivation.

Fixes #27 