### PR TITLE
Fix Rubocop triggering when disabled

### DIFF
--- a/Scripts/main.js
+++ b/Scripts/main.js
@@ -34,7 +34,7 @@ exports.activate = function() {
     langserver = new SolargraphLanguageServer()
   }
 
-  if (SETTINGS.rubocop.autocorrectOnSave()) {
+  if (SETTINGS.rubocop.autocorrectOnSave() != "Disabled") {
     nova.workspace.activeTextEditor.onDidSave((editor) => {
       const rubocop = new COMMANDS.Rubocop()
 


### PR DESCRIPTION
Fixes an issue where Rubocop autocorrection will run even when disabled.

`SETTINGS.rubocop.autocorrectOnSave()` will return a string. When the 'Disabled' option is selected in the settings, this method returns the string 'Disabled' which is a truthy value.

We explicitly check the return value of `autocorrectOnSave()` to determine if we should bind the `onDidSave` event handler to the active text editor.

Fixes #29 