### PR TITLE
RailsDocumentation.js: change to new hotwired.dev domain

### DIFF
--- a/Scripts/commands/RailsDocumentation.js
+++ b/Scripts/commands/RailsDocumentation.js
@@ -11,8 +11,8 @@ exports.RailsDocumentation = class RailsDocumentation {
     this.docsSearchLinks = {
       railsAPI: "https://duckduckgo.com/?t=ffab&q=site%3Aapi.rubyonrails.org+",
       railsGuides: "https://duckduckgo.com/?t=ffab&q=site%3Aguides.rubyonrails.org+",
-      turbo: "https://duckduckgo.com/?t=ffab&q=site%3Aturbo.hotwire.dev+",
-      stimulus: "https://duckduckgo.com/?t=ffab&q=site%3Astimulus.hotwire.dev+",
+      turbo: "https://duckduckgo.com/?t=ffab&q=site%3Aturbo.hotwired.dev+",
+      stimulus: "https://duckduckgo.com/?t=ffab&q=site%3Astimulus.hotwired.dev+",
       rubyDoc: "https://duckduckgo.com/?t=ffab&q=site%3Aruby-doc.org+",
     }
   }


### PR DESCRIPTION
same here. hotwired.dev domain
duckduck is not finding anything on the unredirected hotwire.dev domain